### PR TITLE
AzCopy 10 compatibility fix

### DIFF
--- a/PKI/Invoke-UpdateAzureBlobPKIStorage.ps1
+++ b/PKI/Invoke-UpdateAzureBlobPKIStorage.ps1
@@ -9,7 +9,7 @@ internal web servers and/or opening them up to the Internet through
 a DMZ or via a reverse proxy like Azure AD App Proxy.
 
 Requirements:
-  1. AzCopy installed on the CA server - http://aka.ms/azcopy
+  1. AzCopy 10+ installed on the CA server - http://aka.ms/azcopy
   2. Outbound HTTPS from the CA server to Azure Blob Storage
   3. An Azure Storage Account with blob storage configured for HTTP access
   4. A folder in the blob storage named 'pki' (https://<storageaccountname>.blob.core.windows.net/pki/)
@@ -43,6 +43,7 @@ Todo:       Nothing at the moment
 
 Change Log
 v1.0, 05/10/2018 - Initial version
+05/19/2022 - AzCopy 10 compatibility fix
 #>
 
 # Blob storage location to upload files to

--- a/PKI/Invoke-UpdateAzureBlobPKIStorage.ps1
+++ b/PKI/Invoke-UpdateAzureBlobPKIStorage.ps1
@@ -46,7 +46,7 @@ v1.0, 05/10/2018 - Initial version
 #>
 
 # Blob storage location to upload files to
-$azCopyDestination = "https://<storageaccountname>.blob.core.windows.net/pki/"
+$azCopyDestination = "https://<storageaccountname>.blob.core.windows.net/pki/?"
 
 # SAS key for the above destination
 $azCopyDestinationSASKey = "<YOUR SAS KEY HERE>"
@@ -87,7 +87,7 @@ $ErrorActionPreference = 'Stop'
 
 try {
     # Run AzCopy to copy only .crl files that are newer than already exist at the destination
-    &$azCopyBinaryPath /Source:$cdpLocalLocation /Dest:$azCopyDestination /DestSAS:$azCopyDestinationSASKey /Pattern:"*.crl" /Y /XO /V:$azCopyLogLocation
+    &$azCopyBinaryPath cp $cdpLocalLocation $azCopyDestination$azCopyDestinationSASKey --include-pattern="*.crl" --log-level="error" --check-length=false
     }
 catch {
     $error | Out-File $azCopyLogArchiveLocation -Append


### PR DESCRIPTION
This fixes the syntax for the try / run AzCopy command.  It might break logging.  I couldn't find a reference for what /Y /XO /V meant.  I'm guessing these applied to AzCopy versions < 10.

Also I added a '?' to the end of the $azCopyDestination placeholder text.  It's necessary for the destination & SAS key to work correctly when combined.

I believe $azCopyDestination and $azCopyDestinationSASKey could be combined and use the Blob SAS URL given when generating Shared access tokens.  That would simplify the try line and accomplish the same thing, but I am lazy and this works as-is so long as the '?' is included at the end of $azCopyDestination.

Anyway, this should work with pwsh 7 and AzCopy 10.